### PR TITLE
Fix redundant upload

### DIFF
--- a/biliup/config/11111111.yaml
+++ b/biliup/config/11111111.yaml
@@ -1,7 +1,7 @@
 line: kodo
 limit: 3
 streamers:
-  /root/blive/Videos/11111111/11111111*.mp4:
+  /root/blive/Videos/11111111/%P:
     copyright: 1
     source: https://live.bilibili.com/11111111
     tid: 138

--- a/biliup/config/22222222.yaml
+++ b/biliup/config/22222222.yaml
@@ -1,7 +1,7 @@
 line: kodo
 limit: 3
 streamers:
-  /root/blive/Videos/22222222/22222222*.mp4:
+  /root/blive/Videos/22222222/%P:
     copyright: 1
     source: https://live.bilibili.com/22222222
     tid: 138

--- a/biliup/upload.sh
+++ b/biliup/upload.sh
@@ -17,7 +17,6 @@ trimmed_path="${full_path%.mp4}"
 # 提取房间号和日期时间
 # 使用参数扩展来去除路径，只留下文件名
 file_name=$(basename "$full_path")
-
 # 正则表达式匹配房间号和日期时间
 if [[ $file_name =~ ([0-9]+)_([0-9]{4})-([0-9]{2})-([0-9]{2})-([0-9]{2})\.mp4 ]]; then
     room_id="${BASH_REMATCH[1]}"
@@ -57,6 +56,7 @@ sed -i "s/%Y/$year/g" "$copy_yaml_file"
 sed -i "s/%M/$month/g" "$copy_yaml_file"
 sed -i "s/%d/$day/g" "$copy_yaml_file"
 sed -i "s/%H/$hour/g" "$copy_yaml_file"
+sed -i "s/%P/${file_name}/g" "$copy_yaml_file"
 
 echo "文件名 $file_name 中日期和时间参数已更新到 $copy_yaml_file"
 


### PR DESCRIPTION
## Description

After improvement, each video is uploaded through a unique `yaml` file to ensure that it will not match other videos under the same roomid.

## Related Issues

#10 

## Changes Proposed

- [ ] Modified `yaml` file path matching rules in `biliup.sh`.
- [ ] Modified the `config.yaml` under different roomid.

## Who Can Review?

Self Reviewed.

## TODO

None.

## Checklist

- [x]  Code has been reviewed
- [x]  Code complies with the project's code standards and best practices
- [x]  Code has passed all tests
- [x]  Code does not affect the normal use of existing features
- [x]  Code has been commented properly
- [x]  Documentation has been updated (if applicable)
- [x]  Demo/checkpoint has been attached (if applicable)
