### PR TITLE
feat: add custom path to script

### DIFF
--- a/upload/operateStart.sh
+++ b/upload/operateStart.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
-target_folder="/root/blive/Videos"
+if [ $# -gt 0 ]; then
+    target_folder="$1"
+else
+    target_folder="/root/blive/Videos"
+fi
 
 queue=("$target_folder")
 
@@ -22,4 +26,3 @@ while [ ${#queue[@]} -gt 0 ]; do
         fi
     done
 done
-


### PR DESCRIPTION
## Description

Pass the custom path as a parameter to the script. If no custom path is provided, the default path is the entire video folder.

## Related Issues

#24 

## Changes Proposed

- [ ] Add alternative parameter to `operateStart.sh` script.

## Who Can Review?

@timerring 

## TODO

- [x] Adjust README file.

## Checklist

- [x]  Code has been reviewed
- [x]  Code complies with the project's code standards and best practices
- [x]  Code has passed all tests
- [x]  Code does not affect the normal use of existing features
- [x]  Code has been commented properly
- [x]  Documentation has been updated (if applicable)
- [x]  Demo/checkpoint has been attached (if applicable)
