### PR TITLE
feat: reupload the danmaku ready videos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ Videos/
 test/
 .cache
 .vscode/
+__pycache__/
 
 # Ignore the .log file
 *.log

--- a/upload/DanmakuProcess.sh
+++ b/upload/DanmakuProcess.sh
@@ -8,12 +8,17 @@ export assName
 # use DanmakuFactory to convert the xml file
 /root/blive/DanmakuFactory/DanmakuFactory -o "$assName" -i "$formatXmlName"
 
-#echo "$full_path"
-#echo "$assName"
-#echo "$formatVideoName"
+echo “danmaku convert success! And will delete xml files...”
+
+rm $formatXmlName
+# echo "$full_path"
+# echo "$assName"
+# echo "$formatVideoName"
 
 ffmpeg -i $full_path -vf ass=$assName $formatVideoName
 
-echo "ffmpeg successfully complete!"
+echo "ffmpeg successfully complete! And will delete danmaku files..."
+
+rm $assName
 
 ./uploadVideo.sh $formatVideoName

--- a/upload/operateStart.sh
+++ b/upload/operateStart.sh
@@ -14,14 +14,19 @@ while [ ${#queue[@]} -gt 0 ]; do
     queue=( "${queue[@]}" )
 
     for file in "$current_folder"/*; do
+        # echo "$file"
         if [ -d "$file" ]; then
             queue=( "${queue[@]}" "$file" )
         elif [[ $file == *.mp4 ]]; then
+            absolute_mp4_path=$(readlink -f "$file")
+            # echo "begin mp4 loop"
+	        echo "$absolute_mp4_path"
+            # echo "loop end"
             xml_file="${file%.mp4}.xml"
             if [ -f "$xml_file" ]; then
-	       absolute_mp4_path=$(readlink -f "$file")
-	       echo "$absolute_mp4_path"
-               /root/blive/biliup/formatName.sh "$absolute_mp4_path"
+                /root/blive/biliup/formatName.sh "$absolute_mp4_path"
+            elif [[ $file =~ ^/root/blive/Videos/[0-9]+/[0-9]+_[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{2}\.mp4$ ]]; then
+                /root/blive/biliup/uploadVideo.sh "$absolute_mp4_path"
             fi
         fi
     done


### PR DESCRIPTION
## Description

Fixed the issue that the danmaku ready videos which were not be uploaded due to network problems would be left out.

## Related Issues

#27 
#23 

## Changes Proposed

- [ ] Rebuild the logic of danmaku compress. Deleted the danmaku files at the time they were converted. 
- [ ] And use the existance of danmaku files as a flag to determine whether the video is the danmaku ready video.

## Who Can Review?

@timerring 

## TODO

- [ ] adjust the desciption of readme.

## Checklist

- [ ]  Code has been reviewed
- [ ]  Code complies with the project's code standards and best practices
- [ ]  Code has passed all tests
- [ ]  Code does not affect the normal use of existing features
- [ ]  Code has been commented properly
- [ ]  Documentation has been updated (if applicable)
- [ ]  Demo/checkpoint has been attached (if applicable)
