### PR TITLE
feat: max burning speed

### DIFF
--- a/danmakuProcess.sh
+++ b/danmakuProcess.sh
@@ -22,7 +22,7 @@ rm $formatXmlName
 # echo "$assName"
 # echo "$formatVideoName"
 
-ffmpeg -y -i $full_path -vf ass=$assName $formatVideoName 
+ffmpeg -y -i $full_path -vf ass=$assName -preset superfast $formatVideoName  > $root_path/burnLog/burn-$(date +%Y%m%d%H%M%S).log 2>&1
 
 echo "ffmpeg successfully complete! And will delete danmaku files..."
 

--- a/danmakuProcess.sh
+++ b/danmakuProcess.sh
@@ -22,7 +22,7 @@ rm $formatXmlName
 # echo "$assName"
 # echo "$formatVideoName"
 
-ffmpeg -y -i $full_path -vf ass=$assName -preset superfast $formatVideoName  > $root_path/burnLog/burn-$(date +%Y%m%d%H%M%S).log 2>&1
+ffmpeg -y -i $full_path -vf ass=$assName -preset ultrafast $formatVideoName  > $root_path/burnLog/burn-$(date +%Y%m%d%H%M%S).log 2>&1
 
 echo "ffmpeg successfully complete! And will delete danmaku files..."
 


### PR DESCRIPTION
## Description

I search the ffmpeg documatation and try different bitrates to improve the danmaku burning speed. Eventually use the preset parameter `ultrafast`, which can speed up at 6x compared to the original 0.4x. Thus improve the burning speed and enable the quality of video within a certain tolerance.

## Related Issues

#34 

## Changes Proposed

- [ ] add the `preset` parameter and record the logs.

## Who Can Review?

@timerring 

## TODO

- [ ] none.

## Checklist

- [ ]  Code has been reviewed
- [ ]  Code complies with the project's code standards and best practices
- [ ]  Code has passed all tests
- [ ]  Code does not affect the normal use of existing features
- [ ]  Code has been commented properly
- [ ]  Documentation has been updated (if applicable)
- [ ]  Demo/checkpoint has been attached (if applicable)
