### PR TITLE
feat: merge video segments

### DIFF
--- a/burnAndMerge.sh
+++ b/burnAndMerge.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# DESCRIPTION:
+#   Read the sameVideos.txt and burn them in tmp, then merge them into a integral video.
+#   Eventually, add the integral video to uploadVideoQueue.
+#
+# PARAMETERS:
+#   INPUT:  sameVideos.txt
+#   OUTPUT: uploadVideoQueue.txt
+
+# Import the $root_path
+while read key value; do
+    export $key="$value"
+done < ./path.txt
+echo $root_path
+
+first_output_file=""
+while read -r line; do
+    # Skip when read blanket line
+    echo "==================== deal with $line ======================="
+    if [ -z "$line" ]; then
+        continue
+    fi
+
+    # Convert the danmaku files
+    xml_file=${line%.mp4}.xml
+    ass_file=${line%.mp4}.ass
+    $root_path/DanmakuFactory -o "$ass_file" -i "$xml_file" --ignore-warnings
+    echo "==================== generated $ass_file ===================="
+
+    # Compress the danmaku into video
+    output_file=$(echo "$line" | sed 's/_\([0-9]\{4\}\)\([0-9]\{2\}\)\([0-9]\{2\}\)/_\1-\2-\3/')
+    
+    # Initial some basic parameters
+    if [ -z "$first_output_file" ]; then
+    dir=$(dirname $output_file)
+    first_output_file="${output_file%-[0-9][0-9]-[0-9][0-9].mp4}.mp4"
+    tmp_dir=$dir/tmp
+    mkdir -p "$tmp_dir"
+    echo "==================== create tmp folder $tmp_dir ===================="
+    fi
+
+    file_name=$(basename "$output_file")
+    new_path="$tmp_dir/$file_name"
+    echo "==================== compress $new_path ===================="
+    echo "file '$new_path'" >> mergevideo.txt
+    # echo "ffmpeg -i $line -vf ass=$ass_file $output_file"
+    ffmpeg -i "$line" -vf "ass=$ass_file" -preset ultrafast "$new_path" -y -nostdin  > $root_path/logs/burningLog/burn-$(date +%Y%m%d%H%M%S).log 2>&1
+    # Delete the related items of videos
+    rm ${line%.mp4}.*
+done < sameVideos.txt
+
+# merge the videos
+echo "==================== merge starts ===================="
+# echo "ffmpeg -f concat -i mergevideo.txt -c copy $first_output_file"
+ffmpeg -f concat -safe 0 -i mergevideo.txt -c copy $first_output_file > $root_path/logs/mergeLog/merge-$(date +%Y%m%d%H%M%S).log 2>&1
+
+# delete useless videos and lists
+rm -r $tmp_dir
+rm mergevideo.txt
+
+echo "==================== start upload $first_output_file ===================="
+# echo "nohup /root/blive/uploadVideo.sh $first_output_file > /root/blive/logs/uploadDanmakuLog/$(date +%Y%m%d%H%M%S).log 2>&1 &"
+echo "$first_output_file" >> $root_path/uploadVideoQueue.txt
+echo "==================== OVER ===================="

--- a/checkClips.sh
+++ b/checkClips.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# DESCRIPTION:
+#   Check the recorded folders in loop, if there are the same date videos, handle them in burnAndMerge script. 
+#   Otherwise, handle them in danmakuBurning script.
+#
+# PARAMETERS:
+#   INPUT:  none.
+#   OUTPUT: $same_date_videos > sameVideos.txt
+
+while read key value; do
+    export $key="$value"
+done < ./path.txt
+echo $root_path
+
+check_and_process_folder() {
+    local folder_path=$1
+    local date_part
+    local count=0
+    local same_date_videos=""
+
+    # Check if there are any flv files in the folder.
+    # If exsits, which means the room is under recording.
+    flv_file=("$folder_path"/*.flv)
+    flv_name=$(basename "$flv_file")
+    if [ ${#flv_name} -gt 10 ]; then
+        echo "Found flv files in $folder_path. Skipping."
+        return
+    fi
+
+    # Check if there is the video clips in the same date
+    for mp4_file in "$folder_path"/*.mp4; do
+        detect_name=$(basename "$mp4_file")
+        # This length to prevent processing the burned videos again!
+        if [ ${#detect_name} -gt 27 ]; then
+            date_part=$(basename "$mp4_file" | cut -d '-' -f 1)
+            for other_mp4_file in "$folder_path"/*.mp4; do
+                if [[ $(basename "$other_mp4_file" | cut -d '-' -f 1) == $date_part ]]; then
+                    count=$((count + 1))
+                fi
+            done
+            if [ $count -gt 1 ]; then
+                same_date_videos="$same_date_videos\n$mp4_file"
+            fi
+        fi
+    done
+
+    # If the same date videos exist then merge them
+    if [ -n "$same_date_videos" ]; then
+        echo -e "$same_date_videos" > sameVideos.txt
+        $root_path/burningAndMerge.sh sameVideos.txt
+    else
+    # Else upload the single video via formatname
+        for mp4_file in "$folder_path"/*.mp4; do
+        detect_name=$(basename "$mp4_file")
+        # This length to prevent processing the burned videos again!
+        if [ ${#detect_name} -gt 27 ]; then
+            $root_path/danmakuBurning.sh $mp4_file
+        fi
+        done
+    fi
+}
+
+roomFolderPath="$root_path/Videos"
+while true; do
+    for roomFolder in "$roomFolderPath"/*; do
+        if [ -d "$roomFolder" ]; then
+            check_and_process_folder "$roomFolder"
+        fi
+    done
+    echo "$(date +"%Y-%m-%d %H:%M:%S") There is no file recorded. Check again in 120 seconds."
+    sleep 120
+done


### PR DESCRIPTION
## Description

Write a new logic which can check the video folders first, and if there are any videos with the same date then echo them to sameVideos.txt in order. Then burn the danmaku of videos separately and merge them in the end. If not, use `danmakuBurning.sh` to handle it.


## Related Issues

fix #5

## Changes Proposed

- [ ] `checkclips.sh`
- [ ] `burnAndMerge.sh`

## Who Can Review?

@timerring 

## TODO

- [ ] adjust the README.md

## Checklist

- [ ]  Code has been reviewed
- [ ]  Code complies with the project's code standards and best practices
- [ ]  Code has passed all tests
- [ ]  Code does not affect the normal use of existing features
- [ ]  Code has been commented properly
- [ ]  Documentation has been updated (if applicable)
- [ ]  Demo/checkpoint has been attached (if applicable)
