### PR TITLE
fix: unique upload records

### DIFF
--- a/uploadQueue.sh
+++ b/uploadQueue.sh
@@ -21,6 +21,7 @@ processVideo() {
 }
 
 while true; do
+    uniq $uploadQueue > $tempQueue && mv $tempQueue $uploadQueue
     if [ -s "$uploadQueue" ]; then
         firstLine=$(head -n 1 "$uploadQueue")
         (processVideo "$firstLine") &


### PR DESCRIPTION
## Description

Every time check the queue of uploading, try to unique the records first, which avoids the redundant upload logs.

## Related Issues

fix #62

## Changes Proposed

- [ ] add the `uniq` function to the script.

## Who Can Review?

@timerring 

## Checklist

- [ ]  Code has been reviewed
- [ ]  Code complies with the project's code standards and best practices
- [ ]  Code has passed all tests
- [ ]  Code does not affect the normal use of existing features
- [ ]  Code has been commented properly
- [ ]  Documentation has been updated (if applicable)
- [ ]  Demo/checkpoint has been attached (if applicable)
