### PR TITLE
fix: hot fix on path typo

### DIFF
--- a/burnAndMerge.sh
+++ b/burnAndMerge.sh
@@ -30,7 +30,7 @@ while read -r line; do
     if [ -f "$xml_file" ]; then
         $root_path/DanmakuFactory -o "$ass_file" -i "$xml_file" --ignore-warnings
         echo "==================== generated $ass_file ===================="
-        export ASS_PATH="$assPath"
+        export ASS_PATH="$ass_file"
         python3 $root_path/removeEmojis.py > $root_path/logs/burningLog/remove-$(date +%Y%m%d%H%M%S).log 2>&1
     fi
 


### PR DESCRIPTION
## Description

The former issue is cause by the typo of path. The deep reason is the naming schemes of variables are not uniform.


## Who Can Review?

@timerring 

## TODO

- [ ] Uniform the naming schemes of variables.

## Checklist

- [ ]  Code has been reviewed
- [ ]  Code complies with the project's code standards and best practices
- [ ]  Code has passed all tests
- [ ]  Code does not affect the normal use of existing features
- [ ]  Code has been commented properly
- [ ]  Documentation has been updated (if applicable)
- [ ]  Demo/checkpoint has been attached (if applicable)
