### PR TITLE
refactor: simplified startup scripts

### DIFF
--- a/record.sh
+++ b/record.sh
@@ -8,6 +8,6 @@ export no_proxy=*
 host=0.0.0.0
 port=2233
 
-kill -9 $(pgrep -f blrec)
+kill -9 $(ps aux | grep '[b]lrec' | awk '{print $2}')
 nohup blrec -c $config --open --host $host --port $port > $BILIVE_PATH/logs/blrec.log 2>&1 &
 echo "blrec run success!"

--- a/scan.sh
+++ b/scan.sh
@@ -1,5 +1,5 @@
 # kill the previous scanSegments process
-kill -9 $(pgrep -f src.burn.scan)
+kill -9 $(ps aux | grep 'src.burn.scan' | grep -v grep | awk '{print $2}')
 # start the scanSegments process
 nohup python -m src.burn.scan > $BILIVE_PATH/logs/scanLog/scan-$(date +%Y%m%d-%H%M%S).log 2>&1 &
 # Check if the last command was successful

--- a/upload.sh
+++ b/upload.sh
@@ -1,6 +1,6 @@
 # kill the previous scanSegments process
-kill -9 $(pgrep -f upload)
-kill -9 $(pgrep -f biliup)
+kill -9 $(ps aux | grep '[u]pload' | awk '{print $2}')
+kill -9 $(ps aux | grep '[b]iliup' | awk '{print $2}')
 # start the scanSegments process
 # nohup $BILIVE_PATH/src/upload/uploadQueue.sh > $BILIVE_PATH/logs/uploadQueue.log 2>&1 &
 nohup python -m src.upload.upload > $BILIVE_PATH/logs/uploadLog/upload-$(date +%Y%m%d-%H%M%S).log 2>&1 &


### PR DESCRIPTION
## Description

The `Git bash` in windows doesn't support `pgrep` command, using basic commands as the substitute.

## Related Issues

fix #152

## Who Can Review?

@timerring 

## Checklist

- [ ]  Code has been reviewed
- [ ]  Code complies with the project's code standards and best practices
- [ ]  Code has passed all tests
- [ ]  Code does not affect the normal use of existing features
- [ ]  Code has been commented properly
- [ ]  Documentation has been updated (if applicable)
- [ ]  Demo/checkpoint has been attached (if applicable)
