### PR TITLE
feat: add reserve queue

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -18,6 +18,7 @@ TITLE = "{artist}直播回放-{date}-{title}"
 DESC = "{artist}直播回放，直播间地址：{source_link} 内容仅供娱乐，直播中主播的言论、观点和行为均由主播本人负责，不代表录播员的观点或立场。"
 # You can change the description as you like.
 GIFT_PRICE_FILTER = 1 # The gift whose price is less than this value will be filtered, unit: RMB
+RESERVE_FOR_FIXING = False # If encounter MOOV crash error, delete the video or reserve for fixing
 # ============================ The video slice configuration ==================
 AUTO_SLICE = False
 SLICE_DURATION = 60 # better not exceed 300 seconds

--- a/src/db/conn.py
+++ b/src/db/conn.py
@@ -37,9 +37,9 @@ def get_single_upload_queue():
 def get_all_upload_queue():
     db = connect()
     cursor = db.cursor()
-    cursor.execute("select video_path from upload_queue;")
+    cursor.execute("select id, video_path, locked from upload_queue;")
     rows = cursor.fetchall()
-    result = [{'video_path': row[0]} for row in rows]
+    result = [{'id': row[0], 'video_path': row[1], 'locked': row[2]} for row in rows]
     db.close()
     return result
 
@@ -79,13 +79,29 @@ def update_upload_queue_lock(video_path: str, locked: int):
         print("Update Upload Queue failed.")
         return False
     
-    
-    
+def get_single_lock_queue():
+    db = connect()
+    cursor = db.cursor()
+    cursor.execute("select video_path from upload_queue where locked = 1 limit 1;")
+    row = cursor.fetchone()
+    result = {'video_path': row[0]} if row else None
+    db.close()
+    return result
+
+def get_all_reserve_for_fixing_queue():
+    db = connect()
+    cursor = db.cursor()
+    cursor.execute("select video_path from upload_queue where locked = 2;")
+    rows = cursor.fetchall()
+    result = [{'video_path': row[0]} for row in rows]
+    db.close()
+    return result
+
 if __name__ == "__main__":
     # Create Table
-    create_table()
+    # create_table()
     # Insert Test Data
-    insert_upload_queue('')
+    # insert_upload_queue('')
     # Insert again to check the unique index
     # print(insert_upload_queue(''))
     # Get the single upload queue, shold be {'video_path': 'test.mp4'}
@@ -93,8 +109,8 @@ if __name__ == "__main__":
     # Get all upload queue
     print(get_all_upload_queue())
     # unlock the upload queue
-    update_upload_queue_lock('test.mp4', 0)
+    # update_upload_queue_lock('test.mp4', 0)
     # Delete the upload queue
-    delete_upload_queue('')
+    # delete_upload_queue('')
     # Get the single upload queue after delete, should be None
     print(get_single_upload_queue())


### PR DESCRIPTION
## Description

Add reserve queue, for a normal video whose locked status is 0, it will be uploaded as usual.

But if there is a:
- JIT error(I named it, which means the ffprobe cannot read its metadata in an extremely short period after rendering)
- interrupted error(kill -9 without deleting the record after removing the video)
- just MOOV crash error(the metadata lost).

The video will be locked(1).

When the normal queue is empty, the locked queue will be processed. But in this turn, the vidoe has been generated for a long time, there won't be JIT error, and the interrupted error will delete the record directly. So there will be only the MOOV videos left, and I add the reserve queue. 

If the user decides to reserve the videos, he can just make the `RESERVE_FOR_FIXING = True`, the locked status of the video will be `2`. However, if the flag is `False`, the video with MOOV crash will be deleted directly.

## Related Issues

#224 

## Who Can Review?

@timerring 

## Checklist

- [ ]  Code has been reviewed
- [ ]  Code complies with the project's code standards and best practices
- [ ]  Code has passed all tests
- [ ]  Code does not affect the normal use of existing features
- [ ]  Code has been commented properly
- [ ]  Documentation has been updated (if applicable)
- [ ]  Demo/checkpoint has been attached (if applicable)
