### PR TITLE
Fixed Issue #289

### DIFF
--- a/src/upload/extract_video_info.py
+++ b/src/upload/extract_video_info.py
@@ -76,7 +76,7 @@ def generate_tag(video_path):
     tags = get_bilibili_suggestions(artist_text)
 
     if not tags:
-        tags = ["直播回放", "切片"]
+        tags = "直播回放"
 
     return tags
 

--- a/src/upload/query_search_suggestion.py
+++ b/src/upload/query_search_suggestion.py
@@ -26,10 +26,10 @@ def get_bilibili_suggestions(term):
             f"Request get_bilibili_suggestions failed with status code: {response.status_code}"
         )
         # fallback to default tags
-        return ["直播回放", "切片"]
+        return "直播回放"
     except requests.RequestException as e:
         upload_log.error(f"Request get_bilibili_suggestions failed with exception: {e}")
-        return ["直播回放", "切片"]
+        return "直播回放"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Issue #289 中提到自动上传失败的问题，与 Issue #211 中的问题十分类似，都是冷门主播 B 站没有相关搜索推荐词条。设置的默认 Tag 格式可能与 API 不完全吻合

## Related Issues

Issue #289 & Issue  #211

## Changes Proposed

- [ ] src/upload/extract_video_info.py 中第 79 行，由 `tags = ["直播回放", "切片"] `修改为` tags = "直播回放"`
- [ ] src/upload/query_search_suggestion.py 中第 29 行及 32 行，由 `return ["直播回放", "切片"]` 修改为` return "直播回放"`


## Checklist

- [ ]  Code has been reviewed
- [ ]  Code complies with the project's code standards and best practices
- [ ]  Code has passed all tests
- [ ]  Code does not affect the normal use of existing features
- [ ]  Code has been commented properly
- [ ]  Documentation has been updated (if applicable)
- [ ]  Demo/checkpoint has been attached (if applicable)
