### PR TITLE
Update upload.sh 改用 python3 运行

### DIFF
--- a/upload.sh
+++ b/upload.sh
@@ -2,8 +2,8 @@
 kill -9 $(ps aux | grep 'src.burn.scan' | grep -v grep | awk '{print $2}')
 kill -9 $(ps aux | grep '[u]pload' | awk '{print $2}')
 # start new process
-nohup python -m src.burn.scan > ./logs/runtime/scan-$(date +%Y%m%d-%H%M%S).log 2>&1 &
-nohup python -m src.upload.upload > ./logs/runtime/upload-$(date +%Y%m%d-%H%M%S).log 2>&1 &
+nohup python3 -m src.burn.scan > ./logs/runtime/scan-$(date +%Y%m%d-%H%M%S).log 2>&1 &
+nohup python3 -m src.upload.upload > ./logs/runtime/upload-$(date +%Y%m%d-%H%M%S).log 2>&1 &
 # Check if the last command was successful
 if [ $? -eq 0 ]; then
     echo "Success! Please ignore the 'kill: usage....' if it displays"


### PR DESCRIPTION
## Description

项目使用 Python3.10 版本，这里使用 python3 运行更为合理

## Related Issues

如果用户未安装 python 的话，nohup 会遇到找不到 python 命令的错误。而这里我们确定的是，用户一定安装了 Python3.10，所以建议改为 python3