### PR TITLE
修复merge模式下报错问题

### DIFF
--- a/src/burn/render_then_merge.py
+++ b/src/burn/render_then_merge.py
@@ -89,10 +89,10 @@ def render_then_merge(video_path_list):
             srt_path = original_video_path[:-4] + ".srt"
             jsonl_path = original_video_path[:-4] + ".jsonl"
             # Recoginze the resolution of video
-            video_resolution = get_resolution(original_video_path)
+            resolution_x, resolution_y = get_resolution(original_video_path)
             # Process the danmakus to ass and remove emojis
             subtitle_font_size, subtitle_margin_v = process_danmakus(
-                xml_path, video_resolution
+                xml_path, resolution_x, resolution_y
             )
             # Generate the srt file via whisper model
             generate_subtitle(original_video_path)


### PR DESCRIPTION
原因是在 render_then_merge 函数里，调用 get_resolution 函数获取视频的分辨率时，返回值是一个包含 resolution_x 和 resolution_y 的元组。而在调用 process_danmakus 函数时，只传入了 xml_path 和 video_resolution，process_danmakus 函数需要分别传入 resolution_x 和 resolution_y 这两个参数。
```python
# render_then_merge.py
video_resolution = get_resolution(original_video_path)
subtitle_font_size, subtitle_margin_v = process_danmakus(
    xml_path, video_resolution
)
```